### PR TITLE
Fix for issue 37 (Add Featured Image Credit but not on main page)

### DIFF
--- a/credit-tracker-shortcodes.php
+++ b/credit-tracker-shortcodes.php
@@ -8,14 +8,11 @@
  * @link      http://www.labs64.com
  * @copyright 2013 Labs64
  */
-
-
 // add shortcodes
 add_shortcode('credit_tracker_table', 'credit_tracker_table_shortcode');
 add_filter('img_caption_shortcode', 'credit_tracker_caption_shortcode_filter', 10, 3);
 add_filter('post_gallery', 'credit_tracker_gallery_caption_shortcode_filter', 10, 3);
-add_filter('post_thumbnail_html', 'creddit_tracker_thumbnail', 99, 3);
-
+add_filter('post_thumbnail_html', 'credit_tracker_thumbnail', 99, 3);
 function credit_tracker_table_shortcode($atts)
 {
     $columns_set_default = array(
@@ -32,9 +29,7 @@ function credit_tracker_table_shortcode($atts)
         'link' => __('Link', CREDITTRACKER_SLUG)
     );
     $columns_set_i18n = array_merge($columns_set_default, $columns_set_optional);
-
     $columns_set = implode(",", array_keys($columns_set_default));
-
     extract(shortcode_atts(
             array(
                 'id' => '',
@@ -44,7 +39,6 @@ function credit_tracker_table_shortcode($atts)
                 'only_current_post' => false,
             ), $atts)
     );
-
     if (empty($include_columns)) {
         $include_columns = $columns_set;
     }
@@ -52,28 +46,21 @@ function credit_tracker_table_shortcode($atts)
     foreach ($columns as $key => $value) {
         $columns[$key] = trim($columns[$key]);
     }
-
     if (is_numeric($size)) {
         $size = array($size, $size);
     } else if (stripos($size, 'x') !== false) {
         $size = explode('x', $size);
     }
-
     $request = array(
         'size' => $size,
         'include' => $id,
     );
-
-
     $request['only_current_post'] = isset( $atts['only_current_post'] ) ? boolval( $atts['only_current_post'] ) : false;
-
     $images = credittracker_get_images($request);
-
     $ret = '<table id="credit-tracker-table" class="credit-tracker-' . $style . '"><thead>';
     if ($size !== 'hidden') {
         $ret .= '<th>' . '&nbsp;' . '</th>';
     }
-
     foreach ($columns as $column) {
         if (!empty($column)) {
             $column_name = $columns_set_i18n[$column];
@@ -84,11 +71,9 @@ function credit_tracker_table_shortcode($atts)
         }
     }
     $ret .= '</thead><tbody>';
-
     if (empty($images)) {
         $ret .= '<tr class="credit-tracker-row"><td colspan="6" class="credit-tracker-column-empty">' . __('No images found', CREDITTRACKER_SLUG) . '</td></tr>';
     }
-
     foreach ($images as $image) {
         if (!empty($image['author']) or !empty($image['publisher'])) {
             $ct_copyright_format = credittracker_get_source_copyright($image['source']);
@@ -105,7 +90,6 @@ function credit_tracker_table_shortcode($atts)
             } elseif ($size !== 'hidden') {
                 $ret .= '<td>' . '<img width="' . $image['width'] . '" height="' . $image['height'] . '" src="' . $image['url'] . '" class="attachment-thumbnail" alt="' . $image['alt'] . '">' . '</td>';
             }
-
             foreach ($columns as $column) {
                 if (!empty($column)) {
                     if ($column == 'copyright') {
@@ -120,12 +104,9 @@ function credit_tracker_table_shortcode($atts)
             $ret .= '</tr>';
         }
     }
-
     $ret .= '</tbody></table>';
     return $ret;
-
 }
-
 function credit_tracker_caption_shortcode_filter($val, $attr, $content = null)
 {
     extract(shortcode_atts(
@@ -138,21 +119,17 @@ function credit_tracker_caption_shortcode_filter($val, $attr, $content = null)
                 'type' => 'caption'
             ), $attr)
     );
-
     $ct_override_caption_shortcode = credittracker_get_single_option('ct_override_caption_shortcode');
     if ((bool)$ct_override_caption_shortcode) {
-
         $id_orig = $id;
         if ($id) {
             $id = esc_attr($id);
         }
-
         // extract attachment id
         preg_match("/\d+/", $id, $matches);
         if (!empty($matches)) {
             $id = $matches[0];
         }
-
         // find attachment
         $request = array(
             'size' => 'thumbnail',
@@ -163,7 +140,6 @@ function credit_tracker_caption_shortcode_filter($val, $attr, $content = null)
             return $val;
         }
         $image = reset($images);
-
         $ct_copyright_format = credittracker_get_source_copyright($image['source']);
         if (empty($ct_copyright_format)) {
             $ct_copyright_format = credittracker_get_single_option('ct_copyright_format');
@@ -173,16 +149,13 @@ function credit_tracker_caption_shortcode_filter($val, $attr, $content = null)
             $image['caption'] = $text;
         }
         $ct_copyright = htmlspecialchars_decode(credittracker_process_item_copyright($image, $ct_copyright_format));
-
         $content = str_replace('<img', '<img itemprop="contentUrl"', $content);
         $content = str_replace("%copyright%", $ct_copyright, $content);
         $content = credittracker_process_item_copyright($image, $content);
-
         $style = '';
         if ((int)$width > 0) {
             $style = 'style="width: ' . (int)$width . 'px"';
         }
-
         $ret = '<div id="' . $id_orig . '" class="wp-caption credit-tracker-caption ' . esc_attr($align) . '" itemscope itemtype="http://schema.org/ImageObject" ' . $style . '>';
         $ret .= do_shortcode($content);
         $ret .= '<p class="wp-caption-text" itemprop="copyrightHolder">' . $ct_copyright . '</p>';
@@ -191,13 +164,11 @@ function credit_tracker_caption_shortcode_filter($val, $attr, $content = null)
         $ret .= '<meta itemprop="author" content="' . $image['author'] . '">';
         $ret .= '<meta itemprop="publisher" content="' . $image['publisher'] . '">';
         $ret .= '</div>';
-
         return $ret;
     } else {
         return $val;
     }
 }
-
 /**
  * Filters the post thumbnail markup to add the 'credit' information as figure/ficaption markup.
  *
@@ -207,32 +178,39 @@ function credit_tracker_caption_shortcode_filter($val, $attr, $content = null)
  *
  * @return string The modified markup for post thumbnail, if it contains an author for crediting.
  */
-function creddit_tracker_thumbnail( $html, $post_id, $post_thumbnail_id )
+function credit_tracker_thumbnail( $html, $post_id, $post_thumbnail_id )
 {
-  $ct_override_caption_thumbnail = credittracker_get_single_option('ct_override_caption_thumbnail');
-  if ((bool)$ct_override_caption_thumbnail and !empty($post_thumbnail_id)) {
+
+    $ct_override_featured_image_caption = credittracker_get_single_option('ct_override_featured_image_caption');
+	
+    if ($ct_override_featured_image_caption==1) {
+	$trigger = false;
+    }
+    else if ($ct_override_featured_image_caption==2 && !is_front_page()) {
+	$trigger = true;
+    }
+    else if ($ct_override_featured_image_caption==3) {
+	$trigger = true;
+    }
+	
+    if ($trigger and !empty($post_thumbnail_id)) {
     // Get the post_meta for the attachment post.
   	$image_post_meta = get_post_meta( $post_thumbnail_id );
-
   	// Get the attachment meta for the attachment post.
   	$attachment_meta = wp_get_attachment_metadata( $post_thumbnail_id );
-
   	// Add title and caption to processed_meta array.
   	$processed_meta = array(
   		'title'   => $attachment_meta['image_meta']['title'],
   		'caption' => $attachment_meta['image_meta']['caption'],
   	);
-
   	// Modify the meta so that it matches what is expected in the `credittracker_process_item_copyright`
   	foreach ( $image_post_meta as $key => $meta ) {
   		$new_key = substr( $key, 15 );
   		$processed_meta[ $new_key ] = $meta[0];
   	}
-
   	// Get the correct copyright text, as set by user in site option, for this thumbnail.
   	$ct_copyright_format = credittracker_get_single_option('ct_copyright_format' );
   	$ct_copyright        = htmlspecialchars_decode( credittracker_process_item_copyright( $processed_meta, $ct_copyright_format ) );
-
   	if ( ! empty( $ct_copyright ) ) {
   		$html = sprintf(
   			'<figure>
@@ -248,7 +226,6 @@ function creddit_tracker_thumbnail( $html, $post_id, $post_thumbnail_id )
   	return $html;
   }
 }
-
 /*MOD
 This function generates the captions for all the images in a gallery.
 Major part of the code is simply a slightly modified copy of gallery_shortcode function in WP media.php (lines 1665-1795 and 1801-1815)
@@ -259,10 +236,8 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
     $ct_override_caption_shortcode = credittracker_get_single_option('ct_override_caption_shortcode');
     if ((bool)$ct_override_caption_shortcode) {
 		
-
 	static $instance = 0;
 	$instance++;
-
 	if ( ! empty( $attr['ids'] ) ) {
 		// 'ids' is explicitly ordered, unless you specify otherwise.
 		if ( empty( $attr['orderby'] ) ) {
@@ -270,9 +245,7 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 		}
 		$attr['include'] = $attr['ids'];
 	}
-
 	
-
 	$html5 = current_theme_supports( 'html5', 'gallery' );
 	$atts = shortcode_atts( array(
 		'order'      => 'ASC',
@@ -287,12 +260,9 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 		'exclude'    => '',
 		'link'       => ''
 	), $attr, 'gallery' );
-
 	$id = intval( $atts['id'] );
-
 	if ( ! empty( $atts['include'] ) ) {
 		$_attachments = get_posts( array( 'include' => $atts['include'], 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $atts['order'], 'orderby' => $atts['orderby'] ) );
-
 		$attachments = array();
 		foreach ( $_attachments as $key => $val ) {
 			$attachments[$val->ID] = $_attachments[$key];
@@ -302,11 +272,9 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 	} else {
 		$attachments = get_children( array( 'post_parent' => $id, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => $atts['order'], 'orderby' => $atts['orderby'] ) );
 	}
-
 	if ( empty( $attachments ) ) {
 		return '';
 	}
-
 	if ( is_feed() ) {
 		$ret = "\n";
 		foreach ( $attachments as $att_id => $attachment ) {
@@ -314,7 +282,6 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 		}
 		return $ret;
 	}
-
 	$itemtag = tag_escape( $atts['itemtag'] );
 	$captiontag = tag_escape( $atts['captiontag'] );
 	$icontag = tag_escape( $atts['icontag'] );
@@ -328,15 +295,11 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 	if ( ! isset( $valid_tags[ $icontag ] ) ) {
 		$icontag = 'dt';
 	}
-
 	$columns = intval( $atts['columns'] );
 	$itemwidth = $columns > 0 ? floor(100/$columns) : 100;
 	$float = is_rtl() ? 'right' : 'left';
-
 	$selector = "gallery-{$instance}";
-
 	$gallery_style = '';
-
 	/**
 	 * Filters whether to print default gallery styles.
 	 *
@@ -367,10 +330,8 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 			/* see gallery_shortcode() in wp-includes/media.php */
 		</style>\n\t\t";
 	
-
 	$size_class = sanitize_html_class( $atts['size'] );
 	$gallery_div = "<div id='$selector' class='gallery galleryid-{$id} gallery-columns-{$columns} gallery-size-{$size_class}'>";
-
 	/**
 	 * Filters the default gallery shortcode CSS styles.
 	 *
@@ -380,10 +341,8 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 	 *                              for the gallery shortcode output.
 	 */
 	$ret = apply_filters( 'gallery_style', $gallery_style . $gallery_div );
-
 	$i = 0;
 	foreach ( $attachments as $id => $attachment ) {
-
 		$attr = ( trim( $attachment->post_excerpt ) ) ? array( 'aria-describedby' => "$selector-$id" ) : '';
 		if ( ! empty( $atts['link'] ) && 'file' === $atts['link'] ) {
 			$image_output = wp_get_attachment_link( $id, $atts['size'], false, false, false, $attr );
@@ -393,7 +352,6 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 			$image_output = wp_get_attachment_link( $id, $atts['size'], true, false, false, $attr );
 		}
 		$image_meta  = wp_get_attachment_metadata( $id );
-
 		$orientation = '';
 		if ( isset( $image_meta['height'], $image_meta['width'] ) ) {
 			$orientation = ( $image_meta['height'] > $image_meta['width'] ) ? 'portrait' : 'landscape';
@@ -416,7 +374,6 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 			if (!empty($matches)) {
 				$id = $matches[0];
 			}
-
 			// find attachment
 			$request = array(
 				'size' => 'thumbnail',
@@ -427,12 +384,10 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 				return $val;
 			}
 			$image = reset($images);	
-
 			// override image caption via 'text' attribute
 			if (!empty($text)) {
 				$image['caption'] = $text;
 			}
-
 			
 			$ct_copyright_format = credittracker_get_source_copyright($image['source']);
 			if (empty($ct_copyright_format)) {
@@ -451,12 +406,10 @@ function credit_tracker_gallery_caption_shortcode_filter($output, $attr, $instan
 			$ret .= '<br style="clear: both" />';
 		}
 	}
-
 	if ( ! $html5 && $columns > 0 && $i % $columns !== 0 ) {
 		$ret .= "
 			<br style='clear: both' />";
 	}
-
 	$ret .= "</div>\n";
     
 		

--- a/options.php
+++ b/options.php
@@ -385,16 +385,18 @@ function credittracker_page_init()
         )
     );
 
-    add_settings_field(
-        'ct_override_caption_thumbnail',
-        __('Thumbnail', CREDITTRACKER_SLUG),
-        'credittracker_checkbox_field_callback',
+	add_settings_field(
+        'ct_override_featured_image_caption',
+        __('Featured Image', CREDITTRACKER_SLUG),
+        'credittracker_FI_radio_button_callback',
         CREDITTRACKER_SLUG,
         'CREDITTRACKER_COMMON_SETTINGS',
         array(
-            'id' => 'ct_override_caption_thumbnail',
-            'caption' => __('Add credit to the post thumbnail (featured image)', CREDITTRACKER_SLUG),
-            'description' => __('', CREDITTRACKER_SLUG),
+            'id' => 'ct_override_featured_image_caption',
+            'caption1' => __('Do not generate credit tracker caption automatically for featured images', CREDITTRACKER_SLUG),
+			'caption2' => __('Generate credit tracker caption automatically for featured images except that of the starting page', CREDITTRACKER_SLUG),
+			'caption3' => __('Generate credit tracker caption automatically for featured images including that of the starting page', CREDITTRACKER_SLUG),
+            'description' => __('<i>(If you have chosen the first or second option and you still find a caption for the featured image of the starting page, that is coded in your theme)</i>', CREDITTRACKER_SLUG),
         )
     );
 
@@ -469,6 +471,18 @@ function credittracker_checkbox_field_callback($args)
     echo "<p class='description'>$description</p>";
 }
 
+function credittracker_FI_radio_button_callback($args)
+{
+    $id = $args['id'];
+    $caption1 = $args['caption1'];
+	$caption2 = $args['caption2'];
+	$caption3 = $args['caption3'];
+    $description = $args['description'];
+    $value = credittracker_get_single_option($id);
+    echo "<input type='radio' id='$id' name='CREDITTRACKER_OPTIONS[$id]' value='1' class='code' " . checked(1, $value, false) . " /> $caption1</br><input type='radio' id='$id' name='CREDITTRACKER_OPTIONS[$id]' value='2' class='code' " . checked(2, $value, false) . " /> $caption2</br><input type='radio' id='$id' name='CREDITTRACKER_OPTIONS[$id]' value='3' class='code' " . checked(3, $value, false) . " /> $caption3</br>";
+    echo "<p class='description'>$description</p>";
+}
+
 /**
  * Returns default options.
  * If you override the options here, be careful to use escape characters!
@@ -480,7 +494,8 @@ function credittracker_get_default_options()
         'ct_copyright_format' => '&copy; %author%',
         'ct_auth_flickr_apikey' => '',
         'ct_override_caption_shortcode' => '0',
-        'ct_override_caption_thumbnail' => '0'
+        'ct_override_caption_thumbnail' => '0',
+		'ct_override_featured_image_caption' => '0'
     );
     return $default_options;
 }

--- a/options.php
+++ b/options.php
@@ -475,8 +475,8 @@ function credittracker_FI_radio_button_callback($args)
 {
     $id = $args['id'];
     $caption1 = $args['caption1'];
-	$caption2 = $args['caption2'];
-	$caption3 = $args['caption3'];
+    $caption2 = $args['caption2'];
+    $caption3 = $args['caption3'];
     $description = $args['description'];
     $value = credittracker_get_single_option($id);
     echo "<input type='radio' id='$id' name='CREDITTRACKER_OPTIONS[$id]' value='1' class='code' " . checked(1, $value, false) . " /> $caption1</br><input type='radio' id='$id' name='CREDITTRACKER_OPTIONS[$id]' value='2' class='code' " . checked(2, $value, false) . " /> $caption2</br><input type='radio' id='$id' name='CREDITTRACKER_OPTIONS[$id]' value='3' class='code' " . checked(3, $value, false) . " /> $caption3</br>";

--- a/options.php
+++ b/options.php
@@ -494,8 +494,7 @@ function credittracker_get_default_options()
         'ct_copyright_format' => '&copy; %author%',
         'ct_auth_flickr_apikey' => '',
         'ct_override_caption_shortcode' => '0',
-        'ct_override_caption_thumbnail' => '0',
-		'ct_override_featured_image_caption' => '0'
+	'ct_override_featured_image_caption' => '0'
     );
     return $default_options;
 }


### PR DESCRIPTION
Hi there,

Here is a possible fix for the 'Add Featured Image Credit but not on main page' issue.
In options.php i replaced a checkbox with radio buttons allowing 3 different choices how captions for the featured images should be generated
In credit-tracker-shortcodes.php the function name 'creddit_tracker_thumbnail' was mistyped, now corrected it to 'credit_tracker_thumbnail' and also enhanced that function to render the caption corresponding the current settings of the plugin