### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/credit-tracker-class.php
+++ b/credit-tracker-class.php
@@ -167,7 +167,7 @@ class Credit_Tracker
         $locale = apply_filters('plugin_locale', get_locale(), $domain);
 
         load_textdomain($domain, trailingslashit(WP_LANG_DIR) . $domain . '/' . $domain . '-' . $locale . '.mo');
-        load_plugin_textdomain($domain, FALSE, basename(dirname(__FILE__)) . '/languages');
+        load_plugin_textdomain($domain, false, basename(dirname(__FILE__)) . '/languages');
     }
 
     /**


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!